### PR TITLE
Add P50/P90, UOPS and SPS Metrics

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -31,6 +31,5 @@ serde_json = { version = "1.0.96", features = ["preserve_order"] }
 url = "2.4.0"
 rand = { version = "0.8.5", features = ["rand_chacha"] }
 lazy_static = "1.4.0"
-colored = "2.0.4"
 sysinfo = "0.29.8"
 crossbeam-queue = "0.3.11"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,13 +17,13 @@ opt-level = 3
 starknet = "0.6.0"
 
 goose = "0.17.2"
-env_logger = "0.10.0"
+env_logger = "0.11.2"
 log = "0.4.17"
 tokio = { version = "1", features = ["full"] }
 futures = "0.3"
 clap = { version = "4.2.7", features = ["derive"] }
 color-eyre = "0.6.2"
-config = "0.13.3"
+config = "0.14.0"
 dotenvy = "0.15.7"
 serde = "1.0.163"
 serde_derive = "1.0.163"
@@ -31,5 +31,5 @@ serde_json = { version = "1.0.96", features = ["preserve_order"] }
 url = "2.4.0"
 rand = { version = "0.8.5", features = ["rand_chacha"] }
 lazy_static = "1.4.0"
-sysinfo = "0.29.8"
+sysinfo = "0.30.5"
 crossbeam-queue = "0.3.11"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,8 +13,9 @@ description = "Gomu Gomu No Gatling is a blazing fast tool to benchmark Starknet
 opt-level = 3
 
 [dependencies]
-# Starknet dependencies
-starknet = "0.6.0"
+# Starknet dependencies, currently the same starknet revision as the one in
+# madara https://github.com/keep-starknet-strange/madara/blob/main/Cargo.toml#L268
+starknet = { git = "https://github.com/xJonathanLEI/starknet-rs.git", rev = "64ebc36" }
 
 goose = "0.17.2"
 env_logger = "0.11.2"

--- a/src/actions/goose.rs
+++ b/src/actions/goose.rs
@@ -83,7 +83,7 @@ pub async fn erc20(shooter: &GatlingShooterSetup) -> color_eyre::Result<GooseMet
                 )
                 .register_transaction(
                     Transaction::new(transfer)
-                        .set_name("Transfer")
+                        .set_name("Transaction Submission")
                         .set_sequence(1),
                 )
                 .register_transaction(
@@ -169,7 +169,11 @@ pub async fn erc721(shooter: &GatlingShooterSetup) -> color_eyre::Result<GooseMe
                         .set_name("Mint Setup")
                         .set_on_start(),
                 )
-                .register_transaction(Transaction::new(mint).set_name("Minting").set_sequence(1))
+                .register_transaction(
+                    Transaction::new(mint)
+                        .set_name("Transaction Submission")
+                        .set_sequence(1),
+                )
                 .register_transaction(
                     Transaction::new(mint_wait)
                         .set_name("Mint Finalizing")

--- a/src/actions/shoot.rs
+++ b/src/actions/shoot.rs
@@ -18,9 +18,8 @@ use starknet::core::types::{
     contract::legacy::LegacyContractClass, BlockId, BlockTag, FieldElement, StarknetError,
 };
 use starknet::macros::{felt, selector};
-use starknet::providers::ProviderError;
 use starknet::providers::{jsonrpc::HttpTransport, JsonRpcClient, Provider};
-use starknet::providers::{MaybeUnknownErrorCode, StarknetErrorWithMessage};
+use starknet::providers::{MaybeUnknownErrorCode, ProviderError, StarknetErrorWithMessage};
 use starknet::signers::{LocalWallet, SigningKey};
 use std::str;
 use std::sync::Arc;

--- a/src/actions/shoot.rs
+++ b/src/actions/shoot.rs
@@ -1,6 +1,6 @@
 use crate::config::{ContractSourceConfig, GatlingConfig};
 use crate::utils::{compute_contract_address, wait_for_tx};
-use color_eyre::eyre::Context;
+use color_eyre::eyre::{Context, OptionExt};
 use color_eyre::{eyre::eyre, Result};
 
 use log::{debug, info, warn};
@@ -86,9 +86,9 @@ impl GatlingShooterSetup {
     }
 
     pub fn environment(&self) -> Result<&GatlingEnvironment> {
-        self.environment.as_ref().ok_or(eyre!(
-            "Environment is not yet populated, you should run the setup function first"
-        ))
+        self.environment
+            .as_ref()
+            .ok_or_eyre("Environment is not yet populated, you should run the setup function first")
     }
 
     pub fn config(&self) -> &GatlingConfig {

--- a/src/metrics.rs
+++ b/src/metrics.rs
@@ -176,7 +176,7 @@ impl BenchmarkReport {
                 value: submission_requests.raw_data.minimum_time.into(),
             },
             MetricResult {
-                name: "Mean Submission Time",
+                name: "Average Submission Time",
                 unit: "milliseconds",
                 value: (submission_requests.raw_data.total_time as f64
                     / submission_requests.success_count as f64)
@@ -193,7 +193,7 @@ impl BenchmarkReport {
                 value: verification_requests.raw_data.minimum_time.into(),
             },
             MetricResult {
-                name: "Mean Verification Time",
+                name: "Average Verification Time",
                 unit: "milliseconds",
                 value: (verification_requests.raw_data.total_time as f64
                     / verification_requests.success_count as f64)

--- a/src/metrics.rs
+++ b/src/metrics.rs
@@ -336,13 +336,14 @@ fn tx_get_user_operations(tx: &Transaction) -> Result<u64> {
         Transaction::Invoke(
             InvokeTransaction::V0(InvokeTransactionV0 { calldata, .. })
             | InvokeTransaction::V1(InvokeTransactionV1 { calldata, .. }),
-        ) => {
+        )
+        | Transaction::L1Handler(L1HandlerTransaction { calldata, .. }) => {
             let &user_operations = calldata
                 .first()
                 .ok_or_eyre("Expected calldata to have at least one field element")?;
 
             user_operations.try_into()?
         }
-        _ => bail!("Unexpected transaction type when getting"),
+        _ => 1 // Other txs can be considered as 1 uop
     })
 }

--- a/src/metrics.rs
+++ b/src/metrics.rs
@@ -204,12 +204,12 @@ impl BenchmarkReport {
             self.metrics.extend_from_slice(&[
                 MetricResult {
                     name: "P90 Submission Time",
-                    unit: "milliseconds",
+                    unit: GOOSE_TIME_UNIT,
                     value: sub_90.into(),
                 },
                 MetricResult {
                     name: "P50 Submission Time",
-                    unit: "milliseconds",
+                    unit: GOOSE_TIME_UNIT,
                     value: sub_p50.into(),
                 },
             ])
@@ -219,12 +219,12 @@ impl BenchmarkReport {
             self.metrics.extend_from_slice(&[
                 MetricResult {
                     name: "P90 Verification Time",
-                    unit: "milliseconds",
+                    unit: GOOSE_TIME_UNIT,
                     value: ver_p90.into(),
                 },
                 MetricResult {
                     name: "P50 Verification Time",
-                    unit: "milliseconds",
+                    unit: GOOSE_TIME_UNIT,
                     value: ver_p50.into(),
                 },
             ])

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -203,11 +203,6 @@ pub async fn get_blocks_with_txs(
         join_set.spawn(get_block_info(starknet_rpc, block_number));
     }
 
-    // Process the rest
-    while let Some(next) = join_set.join_next().await {
-        results.push(next??)
-    }
-
     async fn get_block_info(
         starknet_rpc: Arc<JsonRpcClient<HttpTransport>>,
         block_number: u64,
@@ -249,6 +244,14 @@ pub async fn get_blocks_with_txs(
 
         Ok((block_with_txs, resources))
     }
+
+    // Process the rest
+    while let Some(next) = join_set.join_next().await {
+        results.push(next??)
+    }
+    
+    // Make sure blocks are in order
+    results.sort_unstable_by_key(|(block, _)| block.block_number);
 
     Ok(results)
 }

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -20,7 +20,7 @@ use starknet::{
 use tokio::task::JoinSet;
 
 use std::time::Duration;
-use sysinfo::{CpuExt, System, SystemExt};
+use sysinfo::System;
 
 lazy_static! {
     pub static ref SYSINFO: SysInfo = SysInfo::new();
@@ -74,8 +74,8 @@ impl SysInfo {
         let cpu = sys.global_cpu_info();
 
         Self {
-            os_name: sys.long_os_version().unwrap().trim().to_string(),
-            kernel_version: sys.kernel_version().unwrap(),
+            os_name: System::long_os_version().unwrap().trim().to_string(),
+            kernel_version: System::kernel_version().unwrap(),
             arch: std::env::consts::ARCH.to_string(),
             cpu_count: sys.cpus().len(),
             cpu_frequency: cpu.frequency(),


### PR DESCRIPTION
This PR is in LimeChain's repo as it currently depends on the `goose_reporting` branch which has not been merged into the main gomu gomu repository. It adds additional metrics to reporting as well as multithreading the already existing data required for TPS and TPB.

UOPS and TPS/TPB is gotten through `get_block_with_txs` which replaces the previous call to `get_block_transaction_count`. This is also now multithreaded with a max of 50 calls to the node at a time to not hit ratelimits. SPS is also gotten via `get_transaction_receipt`'s `execution_resources`.

P50/P90 time for both submission and verification is gotten through a map of times from goose itself. 